### PR TITLE
Add MQTT support for Home Assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Watt Who
 
 A simple Home Assistant helper container to track power consumption of devices.
+The container can publish sensor data via MQTT so Home Assistant can discover
+and display energy usage.
 
 ## Usage
 
@@ -14,7 +16,19 @@ docker build -t watt-who .
 3. Run it:
 
 ```bash
-docker run --rm watt-who
+docker run --rm \
+  -e MQTT_HOST=<your-mqtt-host> \
+  watt-who
 ```
 
 The example configuration contains one device named `Doerautomat`.
+
+### Home Assistant Integration
+
+If your Home Assistant installation provides an MQTT broker, the container can
+publish energy data to it. Set the `MQTT_HOST` environment variable to the host
+name of your broker and ensure Home Assistant's MQTT integration is enabled.
+
+Home Assistant will automatically discover sensors for each configured device
+via MQTT discovery. The energy usage will appear as sensors named
+`<device> Energy`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pyyaml
+paho-mqtt

--- a/watt_who/main.py
+++ b/watt_who/main.py
@@ -1,9 +1,11 @@
 import argparse
+import os
 import random
 import time
 
 from .config import load_config
 from .tracker import PowerTracker
+from .mqtt_client import MqttClient
 
 
 def main():
@@ -15,6 +17,11 @@ def main():
     devices = load_config(args.config)
     tracker = PowerTracker(devices)
 
+    mqtt_client = None
+    if os.getenv("MQTT_DISABLE") != "1":
+        mqtt_client = MqttClient()
+        mqtt_client.publish_discovery(devices.keys())
+
     try:
         while True:
             # In a real application, replace this with actual sensor reading
@@ -22,6 +29,8 @@ def main():
             tracker.update_power(current_power)
             energy = tracker.get_energy_kwh()
             print('\r' + ', '.join(f"{name}: {val:.4f} kWh" for name, val in energy.items()), end='')
+            if mqtt_client:
+                mqtt_client.publish_state(energy)
             time.sleep(args.interval)
     except KeyboardInterrupt:
         print()  # newline

--- a/watt_who/mqtt_client.py
+++ b/watt_who/mqtt_client.py
@@ -1,0 +1,36 @@
+import os
+import json
+from typing import Dict, Iterable
+
+import paho.mqtt.client as mqtt
+
+
+class MqttClient:
+    def __init__(self, prefix: str = "watt_who"):
+        host = os.getenv("MQTT_HOST", "homeassistant")
+        port = int(os.getenv("MQTT_PORT", "1883"))
+        username = os.getenv("MQTT_USERNAME")
+        password = os.getenv("MQTT_PASSWORD")
+        self.prefix = prefix.rstrip('/')
+        self.client = mqtt.Client()
+        if username:
+            self.client.username_pw_set(username, password)
+        self.client.connect(host, port)
+        self.client.loop_start()
+
+    def publish_discovery(self, devices: Iterable[str]):
+        for device in devices:
+            topic = f"homeassistant/sensor/{self.prefix}_{device}/config"
+            payload = {
+                "name": f"{device} Energy",
+                "state_topic": f"{self.prefix}/{device}/energy_kwh",
+                "unit_of_measurement": "kWh",
+                "unique_id": f"{self.prefix}_{device}_energy",
+                "device_class": "energy",
+            }
+            self.client.publish(topic, json.dumps(payload), retain=True)
+
+    def publish_state(self, energy: Dict[str, float]):
+        for device, value in energy.items():
+            topic = f"{self.prefix}/{device}/energy_kwh"
+            self.client.publish(topic, f"{value:.4f}", retain=True)


### PR DESCRIPTION
## Summary
- allow publishing energy data via MQTT so Home Assistant can automatically discover sensors
- document the Home Assistant integration

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6871270813c8832e91d7469be99cd16a