### PR TITLE
Add Home Assistant add-on configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
-CMD ["python", "-m", "watt_who.main", "--config", "devices.yml"]
+CMD ["./run.sh"]

--- a/README.md
+++ b/README.md
@@ -32,3 +32,15 @@ name of your broker and ensure Home Assistant's MQTT integration is enabled.
 Home Assistant will automatically discover sensors for each configured device
 via MQTT discovery. The energy usage will appear as sensors named
 `<device> Energy`.
+
+### Installing as a Home Assistant Add-on
+
+To use this container directly in Home Assistant, add this repository to the
+"Add-on store" as a custom source:
+
+1. Open **Settings -> Add-ons -> Add-on Store**.
+2. Use the menu in the upper right to select **Repositories** and add the URL of
+   this repository.
+3. After the repository is added, the "Watt Who" add-on becomes available for
+   installation. Configure the MQTT options (host, port, username and password)
+   in the add-on settings and start it.

--- a/config.json
+++ b/config.json
@@ -1,0 +1,21 @@
+{
+  "name": "Watt Who",
+  "slug": "watt_who",
+  "description": "Track power usage of devices and publish via MQTT",
+  "version": "0.1.0",
+  "startup": "services",
+  "boot": "auto",
+  "arch": ["amd64", "aarch64", "armv7", "armhf", "i386"],
+  "options": {
+    "mqtt_host": "homeassistant",
+    "mqtt_port": 1883,
+    "mqtt_username": "",
+    "mqtt_password": ""
+  },
+  "schema": {
+    "mqtt_host": "str",
+    "mqtt_port": "int",
+    "mqtt_username": "str?",
+    "mqtt_password": "str?"
+  }
+}

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec python -m watt_who.main --config devices.yml


### PR DESCRIPTION
## Summary
- provide add-on config.json with MQTT options
- add run.sh entrypoint
- adjust Dockerfile to use run.sh
- document Home Assistant custom repository installation

## Testing
- `pip install -r requirements.txt`
- `python -m watt_who.main --help`


------
https://chatgpt.com/codex/tasks/task_e_68712cf5731c832e9a7c634dd82eb17f