### PR TITLE
Document optional MQTT variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,32 @@ docker run --rm \
 
 The example configuration contains one device named `Doerautomat`.
 
+### Optional Environment Variables
+
+The container uses the following variables to configure the MQTT connection:
+
+- `MQTT_PORT` – Port of the MQTT broker (default `1883`).
+- `MQTT_USERNAME` – Username for broker authentication.
+- `MQTT_PASSWORD` – Password for broker authentication.
+- `MQTT_DISABLE` – Set to `1` to disable MQTT entirely.
+
+Example with all options:
+
+```bash
+docker run --rm \
+  -e MQTT_HOST=192.168.1.10 \
+  -e MQTT_PORT=1884 \
+  -e MQTT_USERNAME=myuser \
+  -e MQTT_PASSWORD=mypass \
+  watt-who
+```
+
+To run without MQTT, pass `MQTT_DISABLE=1`:
+
+```bash
+docker run --rm -e MQTT_DISABLE=1 watt-who
+```
+
 ### Home Assistant Integration
 
 If your Home Assistant installation provides an MQTT broker, the container can
@@ -44,3 +70,15 @@ To use this container directly in Home Assistant, add this repository to the
 3. After the repository is added, the "Watt Who" add-on becomes available for
    installation. Configure the MQTT options (host, port, username and password)
    in the add-on settings and start it.
+
+Example configuration:
+
+```yaml
+mqtt_host: 192.168.1.10
+mqtt_port: 1884
+mqtt_username: myuser
+mqtt_password: mypass
+```
+
+You can disable MQTT in the add-on by defining the `MQTT_DISABLE` environment
+variable with the value `1` in the add-on options.


### PR DESCRIPTION
## Summary
- document `MQTT_PORT`, `MQTT_USERNAME`, `MQTT_PASSWORD` and `MQTT_DISABLE`
- add Docker command example using these variables
- show sample add-on configuration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68713029f948832ea08135ce84324537