### PR TITLE
Add Home Assistant API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,10 @@ To use this container directly in Home Assistant, add this repository to the
    this repository.
 3. After the repository is added, the "Watt Who" add-on becomes available for
    installation. Configure the MQTT options (host, port, username and password)
-   in the add-on settings and start it.
+   in the add-on settings. To update sensor states via the Home Assistant REST
+   API, enable the option `homeassistant_api: true`. The add-on requires the
+   **Home Assistant Core API** permission for this feature. Start the add-on
+   after saving the settings.
 
 ## License
 

--- a/config.json
+++ b/config.json
@@ -11,11 +11,13 @@
     "mqtt_port": 1883,
     "mqtt_username": "",
     "mqtt_password": ""
+    ,"homeassistant_api": false
   },
   "schema": {
     "mqtt_host": "str",
     "mqtt_port": "int",
     "mqtt_username": "str?",
     "mqtt_password": "str?"
+    ,"homeassistant_api": "bool"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pyyaml
 paho-mqtt
+requests

--- a/watt_who/ha_client.py
+++ b/watt_who/ha_client.py
@@ -1,0 +1,29 @@
+import os
+from typing import Dict
+import requests
+
+class HaClient:
+    def __init__(self, prefix: str = "watt_who", base_url: str = "http://supervisor/core/api"):
+        self.prefix = prefix.rstrip("/")
+        self.base_url = base_url.rstrip("/")
+        token = os.getenv("SUPERVISOR_TOKEN")
+        if not token:
+            raise RuntimeError("SUPERVISOR_TOKEN not set")
+        self.session = requests.Session()
+        self.session.headers.update({
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        })
+
+    def publish_state(self, energy: Dict[str, float]):
+        for device, value in energy.items():
+            entity_id = f"sensor.{self.prefix}_{device}_energy"
+            url = f"{self.base_url}/states/{entity_id}"
+            payload = {
+                "state": f"{value:.4f}",
+                "attributes": {
+                    "unit_of_measurement": "kWh",
+                },
+            }
+            resp = self.session.post(url, json=payload)
+            resp.raise_for_status()

--- a/watt_who/main.py
+++ b/watt_who/main.py
@@ -6,6 +6,7 @@ import time
 from .config import load_config
 from .tracker import PowerTracker
 from .mqtt_client import MqttClient
+from .ha_client import HaClient
 
 
 def main():
@@ -22,6 +23,10 @@ def main():
         mqtt_client = MqttClient()
         mqtt_client.publish_discovery(devices.keys())
 
+    ha_client = None
+    if os.getenv("HOMEASSISTANT_API", "false").lower() == "true":
+        ha_client = HaClient()
+
     try:
         while True:
             # In a real application, replace this with actual sensor reading
@@ -31,6 +36,8 @@ def main():
             print('\r' + ', '.join(f"{name}: {val:.4f} kWh" for name, val in energy.items()), end='')
             if mqtt_client:
                 mqtt_client.publish_state(energy)
+            if ha_client:
+                ha_client.publish_state(energy)
             time.sleep(args.interval)
     except KeyboardInterrupt:
         print()  # newline


### PR DESCRIPTION
## Summary
- allow enabling the Home Assistant API via `homeassistant_api` option
- implement `HaClient` for REST API updates
- publish sensor states via REST API when enabled
- document new option and required permission
- add `requests` dependency

## Testing
- `pip install -r requirements.txt`
- `python -m watt_who.main --help`


------
https://chatgpt.com/codex/tasks/task_e_68713c714148832e8b835b06a43c62ea