### PR TITLE
Add configuration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,38 @@ verbose debug output.
 
 The example configuration contains one device named `Doerautomat`.
 
+## Configuration
+
+Device settings can be provided at runtime via the `--devices` option. The value
+can be a path to a YAML or JSON file, or a literal configuration string. If the
+option is omitted, Watt Who falls back to `/config/devices.yml`.
+
+Example YAML:
+
+```yaml
+Doerautomat:
+  peak_power: 340
+  threshold: 0.95
+  peak_duration: 3
+  cycle:
+    on: 3
+    off: 7
+    power: 360
+```
+
+Equivalent JSON:
+
+```json
+{
+  "Doerautomat": {
+    "peak_power": 340,
+    "threshold": 0.95,
+    "peak_duration": 3,
+    "cycle": { "on": 3, "off": 7, "power": 360 }
+  }
+}
+```
+
 ### Home Assistant Integration
 
 The container requires the `SUPERVISOR_TOKEN` environment variable so it can


### PR DESCRIPTION
## Summary
- document new 'devices' option
- mention fallback to `/config/devices.yml`
- show simple YAML and JSON examples

## Testing
- `pip install -r requirements.txt`
- `python -m watt_who.main --help`

------
https://chatgpt.com/codex/tasks/task_e_6872d9a375d0832eb0cbf3342c95559d