### PR TITLE
Support devices from add-on options

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,26 @@ verbose debug output.
 
 The example configuration contains one device named `Doerautomat`.
 
+## Configuration
+
+When running as an add-on, devices can be configured directly in the add-on
+settings. Add a `devices` list with the same fields used in `devices.yml`:
+
+```yaml
+devices:
+  - name: Doerautomat
+    peak_power: 340
+    threshold: 0.95
+    peak_duration: 3
+    cycle:
+      on: 3
+      off: 7
+      power: 360
+```
+
+You may still provide a `/config/devices.yml` file; however, the add-on options
+take precedence when defined.
+
 ### Home Assistant Integration
 
 The container requires the `SUPERVISOR_TOKEN` environment variable so it can

--- a/config.json
+++ b/config.json
@@ -7,9 +7,23 @@
   "boot": "auto",
   "arch": ["amd64", "aarch64", "armv7", "armhf", "i386"],
   "options": {
-    "debug": false
+    "debug": false,
+    "devices": []
   },
   "schema": {
-    "debug": "bool"
+    "debug": "bool",
+    "devices": [
+      {
+        "name": "str",
+        "peak_power": "float",
+        "threshold": "float?",
+        "peak_duration": "float?",
+        "cycle": {
+          "on": "float?",
+          "off": "float?",
+          "power": "float?"
+        }
+      }
+    ]
   }
 }

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 # Look for the device configuration next to Home Assistant's configuration.yaml
-exec python -m watt_who.main --config /config/devices.yml
+exec python -m watt_who.main --config /config/devices.yml --options /data/options.json

--- a/watt_who/config.py
+++ b/watt_who/config.py
@@ -1,4 +1,5 @@
 import yaml
+import json
 from dataclasses import dataclass
 from typing import Dict, Any
 
@@ -19,7 +20,15 @@ class DeviceConfig:
 
 def load_config(path: str) -> Dict[str, DeviceConfig]:
     with open(path, 'r') as f:
-        data = yaml.safe_load(f) or {}
+        if path.endswith('.json'):
+            opts = json.load(f) or {}
+            devices_in = opts.get('devices', opts)
+            if isinstance(devices_in, list):
+                data = {d.get('name', f'device_{i}'): d for i, d in enumerate(devices_in)}
+            else:
+                data = devices_in
+        else:
+            data = yaml.safe_load(f) or {}
     devices = {}
     for name, cfg in data.items():
         cycle_cfg = cfg.get('cycle', {})

--- a/watt_who/main.py
+++ b/watt_who/main.py
@@ -12,6 +12,7 @@ from .ha_client import HaClient
 def main():
     parser = argparse.ArgumentParser(description="Simple power tracker")
     parser.add_argument('--config', default='/config/devices.yml', help='Path to device config')
+    parser.add_argument('--options', default='/data/options.json', help='Add-on options file')
     parser.add_argument('--interval', type=float, default=1.0, help='Sampling interval in seconds')
     parser.add_argument('--debug', action='store_true', help='Enable debug output')
     args = parser.parse_args()
@@ -19,7 +20,10 @@ def main():
     logging.basicConfig(level=logging.DEBUG if args.debug or os.getenv('DEBUG') == '1' else logging.INFO,
                         format='[%(levelname)s] %(message)s')
 
-    devices = load_config(args.config)
+    config_path = args.config
+    if os.path.exists(args.options):
+        config_path = args.options
+    devices = load_config(config_path)
     tracker = PowerTracker(devices)
 
     ha_client = HaClient()


### PR DESCRIPTION
## Summary
- add a `devices` option with schema to `config.json`
- load `/data/options.json` automatically if present
- extend `watt_who.config.load_config` to parse JSON options
- document device setup in add-on settings

## Testing
- `python -m compileall -q watt_who`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_6872d945ee70832ea88e1159d1484424