### PR TITLE
Add docs for configuring devices via add‑on options

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,23 @@ The example configuration contains one device named `Doerautomat`.
 
 ## Configuration
 
+When running as an add-on, devices can be configured directly in the add-on
+settings. Add a `devices` list with the same fields used in `devices.yml`:
+
+```yaml
+devices:
+  - name: Doerautomat
+    peak_power: 340
+    threshold: 0.95
+    peak_duration: 3
+    cycle:
+      on: 3
+      off: 7
+      power: 360
+```
+
+You may still provide a `/config/devices.yml` file; however, the add-on options
+take precedence when defined.
 
 
 ### Home Assistant Integration


### PR DESCRIPTION
## Summary
- document configuring devices in the add-on settings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687caeb87724832eb6dcb222b21ae84a