### PR TITLE
Add Home Assistant repository manifest and architecture list

### DIFF
--- a/nilm_mvp/config.yaml
+++ b/nilm_mvp/config.yaml
@@ -2,6 +2,12 @@ name: NILM MVP
 version: "0.1.0"
 slug: nilm_mvp
 description: "Einfaches NILM Add-on"
+arch:
+  - aarch64
+  - amd64
+  - armv7
+  - armhf
+  - i386
 startup: application
 boot: auto
 options:

--- a/repository.json
+++ b/repository.json
@@ -1,0 +1,5 @@
+{
+  "name": "Watt Who",
+  "url": "https://github.com/fefi-byte/Watt-Who",
+  "maintainer": "Felix Peters"
+}

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,6 +1,0 @@
-name: "Watt Who"
-url: "https://github.com/fefi-byte/Watt-Who"
-maintainer: "Felix Peters"
-addons:
-  watt_who:
-    repository: "watt who"


### PR DESCRIPTION
## Summary
- add required `repository.json` metadata so Home Assistant recognizes the repository
- define supported CPU architectures in `nilm_mvp/config.yaml`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897c4719dfc832ea2678ac8416514f6