### PR TITLE
Fix main module imports

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,9 +1,14 @@
 import asyncio
+import sys
+from pathlib import Path
 
-from .config import load_config
-from .detection import DeltaPDetector
-from .ha_integration import sensor_data_stream
-from .storage import Storage
+# Ensure the repository root is on the Python path when running directly
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from app.config import load_config
+from app.detection import DeltaPDetector
+from app.ha_integration import sensor_data_stream
+from app.storage import Storage
 
 
 async def main() -> None:


### PR DESCRIPTION
## Summary
- ensure app/main.py can run as a script by adding repository root to `sys.path`
- switch to absolute imports in `app.main`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897dfcc1548832ea98c2c5726fa1694