### PR TITLE
Use package imports and module execution

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,9 +1,9 @@
-import asyncio
-import sys
-from pathlib import Path
+"""Entry point for the CLI.
 
-# Ensure the repository root is on the Python path when running directly
-sys.path.append(str(Path(__file__).resolve().parent.parent))
+Run with ``python -m app.main``.
+"""
+
+import asyncio
 
 from app.config import load_config
 from app.detection import DeltaPDetector


### PR DESCRIPTION
## Summary
- remove manual path manipulation in `app.main` and rely on package imports
- document module entry point and how to run with `python -m app.main`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897e30717e8832ea9bf91232ab9dbb1